### PR TITLE
Add caching of test data in gh actions worklfow

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,6 +31,13 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
     steps:
+      - name: Cache Test Data
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.NeuralPlayground/*
+          key: cached-test-data
+          enableCrossOsArchive: true
       - uses: neuroinformatics-unit/actions/test@v2.0.0
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Closes #71 

Hopefully, this will avoid having to download the test data on every testing environment/OS.
Is should speed up the CI checks significantly.