### PR TITLE
Compatibility with numpy 2.0

### DIFF
--- a/neuralplayground/agents/whittington_2020_extras/whittington_2020_utils.py
+++ b/neuralplayground/agents/whittington_2020_extras/whittington_2020_utils.py
@@ -325,7 +325,7 @@ def check_wall(pre_state, new_state, wall, wall_closenes=1e-5, tolerance=1e-9):
     larger_than_zero = intersection >= 0
 
     # If condition is true, then the points cross the wall
-    cross_wall = np.alltrue(np.logical_and(smaller_than_one, larger_than_zero))
+    cross_wall = np.all(np.logical_and(smaller_than_one, larger_than_zero))
     if cross_wall:
         new_state = (intersection[-1] - wall_closenes) * (new_state - pre_state) + pre_state
 

--- a/neuralplayground/utils.py
+++ b/neuralplayground/utils.py
@@ -49,7 +49,7 @@ def check_crossing_wall(
     larger_than_zero = intersection >= 0
 
     # If condition is true, then the points cross the wall
-    cross_wall = np.alltrue(np.logical_and(smaller_than_one, larger_than_zero))
+    cross_wall = np.all(np.logical_and(smaller_than_one, larger_than_zero))
     if cross_wall:
         new_state = (intersection[-1] - wall_closenes) * (new_state - pre_state) + pre_state
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,10 @@ ignore = [
 [tool.ruff]
 line-length = 127
 exclude = ["__init__.py","build",".eggs"]
-select = ["I", "E", "F"]
 fix = true
+
+[tool.ruff.lint]
+select = ["I", "E", "F", "NPY201"]
 
 [tool.cibuildwheel]
 build = "cp38-* cp39-* cp310-* cp311-*"


### PR DESCRIPTION
Closes #107 

- Replaces the deprecated `np.alltrue` with `np.all` to be compatible with numpy 2.0.
- Also adds a linting rule that should catch any numpy 2.0 incompatibilities in the future.

Merging this PR is required for unblocking all other open PRs, including #101 and #108.