### PR TITLE
Remove cibuildwheel configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,9 +100,3 @@ fix = true
 
 [tool.ruff.lint]
 select = ["I", "E", "F", "NPY201"]
-
-[tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-* cp311-*"
-
-[tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]


### PR DESCRIPTION
There's no compiled code in this repo (as far as I'm aware), so this config isn't needed. 