### PR TITLE
fixing agent history to pop first element when exceding 1000 items

### DIFF
--- a/neuralplayground/agents/agent_core.py
+++ b/neuralplayground/agents/agent_core.py
@@ -80,9 +80,7 @@ class AgentCore(object):
 
         self.obs_history.append(obs)
         if len(self.obs_history) >= 1000:  # reset every 1000
-            self.obs_history = [
-                obs,
-            ]
+            self.obs_history.pop(0)
         if policy_func is not None:
             return policy_func(obs)
 


### PR DESCRIPTION
small bug fix to keep a constant size history list in agent core class