### PR TITLE
Fix deprecation warnings raised by tests

### DIFF
--- a/neuralplayground/arenas/discritized_objects.py
+++ b/neuralplayground/arenas/discritized_objects.py
@@ -413,9 +413,15 @@ class DiscreteObjectEnvironment(Environment):
         history = self.history[-history_length:]
         ax = self.plot_trajectory(history_data=history, ax=ax)
         canvas.draw()
-        image = np.frombuffer(canvas.tostring_rgb(), dtype="uint8")
-        image = image.reshape(f.canvas.get_width_height()[::-1] + (3,))
-        print(image.shape)
+        width, height = f.canvas.get_width_height()
+        # Get the RGBA buffer from the canvas
+        image = np.frombuffer(canvas.buffer_rgba(), dtype="uint8")
+        image = image.reshape((height, width, 4))
+        # Remove the alpha channel (RGBA -> RGB)
+        image_rgb = image[:, :, :3]
+        # Convert RGB to BGR for OpenCV
+        image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
+        print(image_bgr.shape)
         if display:
-            cv2.imshow("2D_env", image)
+            cv2.imshow("2D_env", image_bgr)
             cv2.waitKey(10)

--- a/neuralplayground/arenas/discritized_objects.py
+++ b/neuralplayground/arenas/discritized_objects.py
@@ -97,8 +97,8 @@ class DiscreteObjectEnvironment(Environment):
         self.arena_limits = np.array(
             [[self.arena_x_limits[0], self.arena_x_limits[1]], [self.arena_y_limits[0], self.arena_y_limits[1]]]
         )
-        self.room_width = np.diff(self.arena_x_limits)[0]
-        self.room_depth = np.diff(self.arena_y_limits)[0]
+        self.room_width = np.diff(self.arena_x_limits)[0].item()
+        self.room_depth = np.diff(self.arena_y_limits)[0].item()
         self.agent_step_size = env_kwargs["agent_step_size"]
         self._create_default_walls()
         self._create_custom_walls()

--- a/neuralplayground/arenas/simple2d.py
+++ b/neuralplayground/arenas/simple2d.py
@@ -107,8 +107,8 @@ class Simple2D(Environment):
                 [self.arena_y_limits[0], self.arena_y_limits[1]],
             ]
         )
-        self.room_width = np.diff(self.arena_x_limits)[0]
-        self.room_depth = np.diff(self.arena_y_limits)[0]
+        self.room_width = np.diff(self.arena_x_limits)[0].item()
+        self.room_depth = np.diff(self.arena_y_limits)[0].item()
         self.observation_space = Box(
             low=np.array([self.arena_x_limits[0], self.arena_y_limits[0]]),
             high=np.array([self.arena_x_limits[1], self.arena_y_limits[1]]),

--- a/neuralplayground/arenas/simple2d.py
+++ b/neuralplayground/arenas/simple2d.py
@@ -354,9 +354,15 @@ class Simple2D(Environment):
         history = self.history[-history_length:]
         ax = self.plot_trajectory(history_data=history, ax=ax)
         canvas.draw()
-        image = np.frombuffer(canvas.tostring_rgb(), dtype="uint8")
-        image = image.reshape(f.canvas.get_width_height()[::-1] + (3,))
-        print(image.shape)
+        width, height = f.canvas.get_width_height()
+        # Get the RGBA buffer from the canvas
+        image = np.frombuffer(canvas.buffer_rgba(), dtype="uint8")
+        image = image.reshape((height, width, 4))
+        # Remove the alpha channel (RGBA -> RGB)
+        image_rgb = image[:, :, :3]
+        # Convert RGB to BGR for OpenCV
+        image_bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
+        print(image_bgr.shape)
         if display:
-            cv2.imshow("2D_env", image)
+            cv2.imshow("2D_env", image_bgr)
             cv2.waitKey(10)


### PR DESCRIPTION
The tests were catching some `DeprecationWarniing`s about some specific syntax elements that will not be supported in future versions of `numpy` and `matplotlib`.

In the process of fixing the `matplotlib` warning, I also discovered a missing colorspace conversion from `RGB` to `BGR` (needed for `cv2` to properly display colors in the render plots). I've fixed that, but it may no longer be relevant if we decide to drop `cv2`, as suggested in #117.