### PR TITLE
Update python versions to adhere to SPEC0

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
     steps:
       - name: Cache Test Data

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ We advise you to install the package in a virtual environment,
 to avoid conflicts with other packages. For example, using `conda`:
 
 ```python
-conda create --name NPG-env python=3.10
+conda create --name NPG-env python=3.12
 conda activate NPG-env
 conda install pip
 ```

--- a/neuralplayground/arenas/discritized_objects.py
+++ b/neuralplayground/arenas/discritized_objects.py
@@ -413,8 +413,10 @@ class DiscreteObjectEnvironment(Environment):
         history = self.history[-history_length:]
         ax = self.plot_trajectory(history_data=history, ax=ax)
         canvas.draw()
-        image = np.frombuffer(canvas.tostring_rgb(), dtype="uint8")
-        image = image.reshape(f.canvas.get_width_height()[::-1] + (3,))
+        image = np.frombuffer(canvas.buffer_rgba(), dtype="uint8")
+        image = image.reshape(f.canvas.get_width_height()[::-1] + (4,))
+        image = cv2.cvtColor(image, cv2.COLOR_RGBA2RGB)
+
         print(image.shape)
         if display:
             cv2.imshow("2D_env", image)

--- a/neuralplayground/arenas/simple2d.py
+++ b/neuralplayground/arenas/simple2d.py
@@ -354,8 +354,10 @@ class Simple2D(Environment):
         history = self.history[-history_length:]
         ax = self.plot_trajectory(history_data=history, ax=ax)
         canvas.draw()
-        image = np.frombuffer(canvas.tostring_rgb(), dtype="uint8")
-        image = image.reshape(f.canvas.get_width_height()[::-1] + (3,))
+        image = np.frombuffer(canvas.buffer_rgba(), dtype="uint8")
+        image = image.reshape(f.canvas.get_width_height()[::-1] + (4,))
+        image = cv2.cvtColor(image, cv2.COLOR_RGBA2RGB)
+
         print(image.shape)
         if display:
             cv2.imshow("2D_env", image)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "The standardised environment for the hippocampus and entorhinal cortex models"
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.11.0"
 dynamic = ["version"]
 
 license = {text = "MIT"}
@@ -15,10 +15,9 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: MIT License",
 ]
@@ -79,7 +78,7 @@ exclude = ["tests*"]
 addopts = "--cov=neuralplayground"
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py311', 'py312', 'py313']
 skip-string-normalization = false
 line-length = 127
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist = py{38,39,310,311}
+envlist = py{311,312,313}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
-    3.10: py310
     3.11: py311
+    3.12: py312
+    3.13: py313
 
 [testenv]
 passenv =


### PR DESCRIPTION
This PR updates the supported and tested Python versions to adhere to [SPEC0](https://scientific-python.org/specs/spec-0000/), i.e. 3.11-3.13. I've updated the recommended version in the readme to 3.12, just in case there are any issues with the latest version. 

I've also made some changes to the use of the matplotlib API as `.tostring_rgb()` has been deprecated. This should make the tests pass, but it would be worth testing in "real" use to make sure it hasn't messed up the plotting.