### PR TITLE
Fix color order for cv2

### DIFF
--- a/neuralplayground/arenas/discritized_objects.py
+++ b/neuralplayground/arenas/discritized_objects.py
@@ -415,7 +415,7 @@ class DiscreteObjectEnvironment(Environment):
         canvas.draw()
         image = np.frombuffer(canvas.buffer_rgba(), dtype="uint8")
         image = image.reshape(f.canvas.get_width_height()[::-1] + (4,))
-        image = cv2.cvtColor(image, cv2.COLOR_RGBA2RGB)
+        image = cv2.cvtColor(image, cv2.COLOR_RGBA2BGR)
 
         print(image.shape)
         if display:

--- a/neuralplayground/arenas/discritized_objects.py
+++ b/neuralplayground/arenas/discritized_objects.py
@@ -97,8 +97,8 @@ class DiscreteObjectEnvironment(Environment):
         self.arena_limits = np.array(
             [[self.arena_x_limits[0], self.arena_x_limits[1]], [self.arena_y_limits[0], self.arena_y_limits[1]]]
         )
-        self.room_width = np.diff(self.arena_x_limits)[0]
-        self.room_depth = np.diff(self.arena_y_limits)[0]
+        self.room_width = np.diff(self.arena_x_limits)[0].item()
+        self.room_depth = np.diff(self.arena_y_limits)[0].item()
         self.agent_step_size = env_kwargs["agent_step_size"]
         self._create_default_walls()
         self._create_custom_walls()

--- a/neuralplayground/arenas/simple2d.py
+++ b/neuralplayground/arenas/simple2d.py
@@ -107,8 +107,8 @@ class Simple2D(Environment):
                 [self.arena_y_limits[0], self.arena_y_limits[1]],
             ]
         )
-        self.room_width = np.diff(self.arena_x_limits)[0]
-        self.room_depth = np.diff(self.arena_y_limits)[0]
+        self.room_width = np.diff(self.arena_x_limits)[0].item()
+        self.room_depth = np.diff(self.arena_y_limits)[0].item()
         self.observation_space = Box(
             low=np.array([self.arena_x_limits[0], self.arena_y_limits[0]]),
             high=np.array([self.arena_x_limits[1], self.arena_y_limits[1]]),

--- a/neuralplayground/arenas/simple2d.py
+++ b/neuralplayground/arenas/simple2d.py
@@ -356,7 +356,7 @@ class Simple2D(Environment):
         canvas.draw()
         image = np.frombuffer(canvas.buffer_rgba(), dtype="uint8")
         image = image.reshape(f.canvas.get_width_height()[::-1] + (4,))
-        image = cv2.cvtColor(image, cv2.COLOR_RGBA2RGB)
+        image = cv2.cvtColor(image, cv2.COLOR_RGBA2BGR)
 
         print(image.shape)
         if display:


### PR DESCRIPTION
This PR replaces PR #118.

- It converts the images to be rendered via `cv2.imshow` to a BGR color order (instead of RGB), because that's what `cv2` expects. This can be verified by setting `display=True` in [this test](https://github.com/SainsburyWellcomeCentre/NeuralPlayground/blob/e658dae12eccfdf5652aa5c8f801cd8a7934339e/tests/arena_exp_test.py#L54C40-L54C44) and running the tests locally with RGB vs BGR. The correct colours and colormaps show up only when the image is BGR.
- it fixes some additional deprecation warning that were raised during tests.


