### PR TITLE
Replace NIU upload action with separate actions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -57,7 +57,7 @@ jobs:
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: artifact
         path: dist


### PR DESCRIPTION
The pypi-publish action from within the NIU composite actions any more. This PR updates the upload steps to use the individual actions steps, copied from https://github.com/brainglobe/brainglobe-atlasapi/pull/449.

This change has been tested on every @neuroinformatics-unit and @brainglobe repository, so in theory (famous last words) it should fix the release issue here too. 